### PR TITLE
Implement max timestep

### DIFF
--- a/tests/step_size_controllers_test.py
+++ b/tests/step_size_controllers_test.py
@@ -228,3 +228,41 @@ def test_pid_does_not_update_state_if_step_is_rejected():
     assert (state_next.prev_error_ratio[0] == state.prev_error_ratio[0]).all()
     assert (state_next.prev_prev_error_ratio[0] == state.prev_prev_error_ratio[0]).all()
     assert (state_next.prev_prev_error_ratio[1] == state.prev_error_ratio[1]).all()
+
+@pytest.mark.parametrize(
+    "controller",
+    [
+        PIDController(atol=1.0, rtol=0.0, pcoeff=0, icoeff=1, dcoeff=0, norm=max_norm),
+        IntegralController(atol=1.0, rtol=0.0, norm=max_norm),
+    ],
+)
+def test_limit_step_size(controller):
+    dt_max = torch.tensor(0.4)
+    t0 = torch.tensor([0.0, 1.5])
+    dt = torch.tensor([1.0, 0.5])
+    y0 = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+
+    problem = InitialValueProblem(y0, t0, t0 + dt, t0.reshape((-1, 1)))
+    state = controller.initial_state(method_order=5, problem=problem, dt_min=None, dt_max=dt_max)
+    result = StepResult(y0, torch.full_like(y0, 0.5))
+    accept, dt_next, state_next, status = controller.adapt_step_size(
+        t0, dt, y0, result, state, stats={}
+    )
+
+    assert accept.all()
+    assert (dt_next <= dt_max).all()
+    assert (status == Status.SUCCESS.value).all()
+    if isinstance(state, PIDState):
+        assert (state_next.prev_error_ratio != 1.0).all()
+        assert (state_next.prev_prev_error_ratio == state.prev_error_ratio).all()
+
+    accept, dt_final, state_final, status = controller.adapt_step_size(
+        t0 + dt, dt_next, y0, result, state_next, stats={}
+    )
+
+    assert accept.all()
+    assert (dt_final <= dt_max).all()
+    assert (status == Status.SUCCESS.value).all()
+    if isinstance(state, PIDState):
+        assert (state_next.prev_error_ratio != 1.0).all()
+        assert (state_final.prev_prev_error_ratio == state_final.prev_error_ratio).all()

--- a/tests/step_size_controllers_test.py
+++ b/tests/step_size_controllers_test.py
@@ -27,7 +27,7 @@ def test_no_error_estimate_keeps_step_size_constant(controller):
     y0 = torch.tensor([[1.0, 2.0, 3.0]])
 
     problem = InitialValueProblem(y0, t0, t0 + dt, t0.reshape((-1, 1)))
-    state = controller.initial_state(method_order=5, problem=problem, dt_min=None)
+    state = controller.initial_state(method_order=5, problem=problem, dt_min=None, dt_max=None)
     result = StepResult(y0, None)
     accept, dt_next, state_next, status = controller.adapt_step_size(
         t0, dt, y0, result, state, stats={}
@@ -51,7 +51,7 @@ def test_zero_error_produces_finite_step_size(controller):
     y0 = torch.tensor([[1.0, 2.0, 3.0]])
 
     problem = InitialValueProblem(y0, t0, t0 + dt, t0.reshape((-1, 1)))
-    state = controller.initial_state(method_order=5, problem=problem, dt_min=None)
+    state = controller.initial_state(method_order=5, problem=problem, dt_min=None, dt_max=None)
     result = StepResult(y0, torch.zeros_like(y0))
     _, dt_next, _, _ = controller.adapt_step_size(t0, dt, y0, result, state, stats={})
 
@@ -73,7 +73,7 @@ def test_infinite_error_norm_signals_error_status(controller):
     y0 = torch.ones((batch_size, 2))
 
     problem = InitialValueProblem(y0, t0, t0 + dt, t0.reshape((-1, 1)))
-    state = controller.initial_state(method_order=5, problem=problem, dt_min=None)
+    state = controller.initial_state(method_order=5, problem=problem, dt_min=None, dt_max=None)
     result = StepResult(
         y0,
         error_estimate=torch.tensor(
@@ -103,7 +103,7 @@ def test_nan_y_signals_error_status(controller):
     y0 = torch.tensor([[float("nan"), 1.0], [1.5, 1.0]])
 
     problem = InitialValueProblem(y0, t0, t0 + dt, t0.reshape((-1, 1)))
-    state = controller.initial_state(method_order=5, problem=problem, dt_min=None)
+    state = controller.initial_state(method_order=5, problem=problem, dt_min=None, dt_max=None)
 
     result = StepResult(
         y0,
@@ -128,7 +128,7 @@ def test_accepts_step_if_error_small(controller):
     y0 = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
 
     problem = InitialValueProblem(y0, t0, t0 + dt, t0.reshape((-1, 1)))
-    state = controller.initial_state(method_order=5, problem=problem, dt_min=None)
+    state = controller.initial_state(method_order=5, problem=problem, dt_min=None, dt_max=None)
     result = StepResult(y0, torch.full_like(y0, 0.5))
     accept, dt_next, state_next, status = controller.adapt_step_size(
         t0, dt, y0, result, state, stats={}
@@ -175,7 +175,7 @@ def test_sets_status_on_dt_min(controller):
     y0 = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
 
     problem = InitialValueProblem(y0, t0, t0 + dt, t0.reshape((-1, 1)))
-    state = controller.initial_state(2, problem, dt_min)
+    state = controller.initial_state(2, problem, dt_min, dt_max=None)
 
     # Huge error for the second instance to get a significant decrease in dt
     error = torch.tensor([[0.9, 0.7], [0.0, 100.0]])
@@ -212,7 +212,7 @@ def test_pid_does_not_update_state_if_step_is_rejected():
         safety=1.0,
     )
     problem = InitialValueProblem(y0, t0, t0 + dt, t0.reshape((-1, 1)))
-    state = controller.initial_state(method_order=3, problem=problem, dt_min=None)
+    state = controller.initial_state(method_order=3, problem=problem, dt_min=None, dt_max=None)
     result = StepResult(y0, torch.tensor([[0.0, 0.8, 0.0], [0.0, 0.0, 0.0]]))
 
     state.prev_error_ratio = torch.rand((2,))

--- a/torchode/step_size_controllers.py
+++ b/torchode/step_size_controllers.py
@@ -419,7 +419,7 @@ class IntegralController(nn.Module):
             
         # Enforce the maximum step size
         dt_max = state.dt_max
-        if dt_min is not None:
+        if dt_max is not None:
             # TODO: reuse abs_dt_next if already calculated above
             abs_dt_next = dt_next.abs()
             # Don't really need a status code for this
@@ -766,7 +766,7 @@ class PIDController(nn.Module):
 
         # Enforce the maximum step size
         dt_max = state.dt_max
-        if dt_min is not None:
+        if dt_max is not None:
             # TODO: reuse abs_dt_next if already calculated above
             abs_dt_next = dt_next.abs()
             # Don't really need a status code for this


### PR DESCRIPTION
Hi Martin,

Thanks for this library - just stumbled across it earlier today and wanted to compare it to [diffrax](https://github.com/patrick-kidger/diffrax) and [torchdiffeq](https://github.com/rtqichen/torchdiffeq) for a project I'm working on.

My ODE works best with a time step limit so it doesn't step over sudden changes in gradient - this is possible in the other two libraries but not here! So I decided to just go ahead and implement it for comparison purposes, and it looks like it worked as expected.

I added a unit test as well, and updated the previous one. Hope it's all OK!