### PR TITLE
Replace TensorType subclassing with docstring and inheriting from torch.Tensor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
 dependencies = [
   "sympy ~= 1.10",
   "torch >= 2.0",
-  "torchtyping ~= 0.1.4",
 ]
 
 [project.optional-dependencies]

--- a/torchode/single_step_methods/runge_kutta.py
+++ b/torchode/single_step_methods/runge_kutta.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 import torch
 import torch.nn as nn
-from torchtyping import TensorType
 
 from ..interpolation import LocalInterpolation
 from ..problems import InitialValueProblem
@@ -12,19 +11,43 @@ from ..typing import *
 from .base import StepResult
 
 
-class CoefficientVector(TensorType["nodes"]):
+class CoefficientVector:
+    """
+    Coefficient vector.
+
+    TensorType["nodes"]
+    """
+
     pass
 
 
-class RungeKuttaMatrix(TensorType["nodes", "weights"]):
+class RungeKuttaMatrix:
+    """
+    Runge-Kutta matrix.
+
+    TensorType["nodes", "weights"]
+    """
+
     pass
 
 
-class WeightVector(TensorType["weights"]):
+class WeightVector:
+    """
+    Weight vector.
+
+    TensorType["weights"]
+    """
+
     pass
 
 
-class WeightMatrix(TensorType["rows", "weights"]):
+class WeightMatrix:
+    """
+    Weight matrix.
+
+    TensorType["rows", "weights"]
+    """
+
     pass
 
 

--- a/torchode/single_step_methods/runge_kutta.py
+++ b/torchode/single_step_methods/runge_kutta.py
@@ -11,7 +11,7 @@ from ..typing import *
 from .base import StepResult
 
 
-class CoefficientVector:
+class CoefficientVector(torch.Tensor):
     """
     Coefficient vector.
 
@@ -21,7 +21,7 @@ class CoefficientVector:
     pass
 
 
-class RungeKuttaMatrix:
+class RungeKuttaMatrix(torch.Tensor):
     """
     Runge-Kutta matrix.
 
@@ -31,7 +31,7 @@ class RungeKuttaMatrix:
     pass
 
 
-class WeightVector:
+class WeightVector(torch.Tensor):
     """
     Weight vector.
 
@@ -41,7 +41,7 @@ class WeightVector:
     pass
 
 
-class WeightMatrix:
+class WeightMatrix(torch.Tensor):
     """
     Weight matrix.
 

--- a/torchode/typing.py
+++ b/torchode/typing.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 import torch
-from torchtyping import TensorType, is_float
 
 
 def same_dtype(*tensors: torch.Tensor):
@@ -39,49 +38,102 @@ def same_shape(*tensors: torch.Tensor, dim: Optional[int] = None):
 # Tensor Types #
 ################
 
-# These are subclasses of TensorType instead of using TensorType annotations directly,
-# because TorchScript does not support custom type constructors. In this way, we can
-# continue to document the shapes and types of tensors while being TorchScript
-# compatible, see [1].
-#
-# [1] https://github.com/patrick-kidger/torchtyping/issues/13
 
+class DataTensor:
+    """
+    Data tensor.
 
-class DataTensor(TensorType["batch", "feature", is_float]):
+    TensorType["batch", "feature", is_float]
+    """
+
     pass
 
 
-class NormTensor(TensorType["batch", is_float]):
+class NormTensor:
+    """
+    Norm tensor.
+
+    TensorType["batch", is_float]
+    """
+
     pass
 
 
-class SolutionDataTensor(TensorType["batch", "time", "feature", is_float]):
+class SolutionDataTensor:
+    """
+    Solution data tensor.
+
+    TensorType["batch", "time", "feature", is_float]
+    """
+
     pass
 
 
-class TimeTensor(TensorType["batch", is_float]):
+class TimeTensor:
+    """
+    Time tensor.
+
+    TensorType["batch", is_float]
+    """
+
     pass
 
 
-class EvaluationTimesTensor(TensorType["batch", "time", is_float]):
+class EvaluationTimesTensor:
+    """
+    Evaluation times tensor.
+
+    TensorType["batch", "time", is_float]
+    """
+
     pass
 
 
-class AcceptTensor(TensorType["batch", torch.bool]):
+class AcceptTensor:
+    """
+    Accept tensor.
+
+    TensorType["batch", torch.bool]
+    """
+
     pass
 
 
-class StatusTensor(TensorType["batch", torch.long]):
+class StatusTensor:
+    """
+    Status tensor.
+
+    TensorType["batch", torch.long]
+    """
+
     pass
 
 
-class InterpTimeTensor(TensorType["interp-points", is_float]):
+class InterpTimeTensor:
+    """
+    Interpolation time tensor.
+
+    TensorType["interp-points", is_float]
+    """
+
     pass
 
 
-class InterpDataTensor(TensorType["interp-points", "feature", is_float]):
+class InterpDataTensor:
+    """
+    Interpolation data tensor.
+
+    TensorType["interp-points", "feature", is_float]
+    """
+
     pass
 
 
-class SampleIndexTensor(TensorType["interp-points", torch.long]):
+class SampleIndexTensor:
+    """
+    Sample index tensor.
+
+    TensorType["interp-points", torch.long]
+    """
+
     pass

--- a/torchode/typing.py
+++ b/torchode/typing.py
@@ -39,7 +39,7 @@ def same_shape(*tensors: torch.Tensor, dim: Optional[int] = None):
 ################
 
 
-class DataTensor:
+class DataTensor(torch.Tensor):
     """
     Data tensor.
 
@@ -49,7 +49,7 @@ class DataTensor:
     pass
 
 
-class NormTensor:
+class NormTensor(torch.Tensor):
     """
     Norm tensor.
 
@@ -59,7 +59,7 @@ class NormTensor:
     pass
 
 
-class SolutionDataTensor:
+class SolutionDataTensor(torch.Tensor):
     """
     Solution data tensor.
 
@@ -69,7 +69,7 @@ class SolutionDataTensor:
     pass
 
 
-class TimeTensor:
+class TimeTensor(torch.Tensor):
     """
     Time tensor.
 
@@ -79,7 +79,7 @@ class TimeTensor:
     pass
 
 
-class EvaluationTimesTensor:
+class EvaluationTimesTensor(torch.Tensor):
     """
     Evaluation times tensor.
 
@@ -89,7 +89,7 @@ class EvaluationTimesTensor:
     pass
 
 
-class AcceptTensor:
+class AcceptTensor(torch.Tensor):
     """
     Accept tensor.
 
@@ -99,7 +99,7 @@ class AcceptTensor:
     pass
 
 
-class StatusTensor:
+class StatusTensor(torch.Tensor):
     """
     Status tensor.
 
@@ -109,7 +109,7 @@ class StatusTensor:
     pass
 
 
-class InterpTimeTensor:
+class InterpTimeTensor(torch.Tensor):
     """
     Interpolation time tensor.
 
@@ -119,7 +119,7 @@ class InterpTimeTensor:
     pass
 
 
-class InterpDataTensor:
+class InterpDataTensor(torch.Tensor):
     """
     Interpolation data tensor.
 
@@ -129,7 +129,7 @@ class InterpDataTensor:
     pass
 
 
-class SampleIndexTensor:
+class SampleIndexTensor(torch.Tensor):
     """
     Sample index tensor.
 


### PR DESCRIPTION
Hi! Awesome library.

Unfortunately, `torchtyping` is deprecated and is incompatible with the latest torch nightly builds.

`torchode` only uses `torchtyping.TensorType` for type annotations to avoid breaking TorchScript compatibility. 

I suggest removing the `torchtyping` dependency, subclassing from `torch.Tensor` directly, and documenting the dimension labels in docstrings.
 
https://github.com/patrick-kidger/torchtyping/issues/48
https://github.com/pytorch/pytorch/issues/131463
https://github.com/wootwootwootwoot/ComfyUI-RK-Sampler/issues/1
